### PR TITLE
m-ld-ification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea

--- a/css/index.css
+++ b/css/index.css
@@ -79,6 +79,11 @@ body {
 	text-rendering: optimizeLegibility;
 }
 
+.todoapp a {
+    all: unset;
+	cursor: pointer;
+}
+
 .new-todo,
 .edit {
 	position: relative;

--- a/index.html
+++ b/index.html
@@ -10,12 +10,13 @@
 	<body>
 		<section class="todoapp">
 			<header class="header">
-				<h1>todos</h1>
+				<h1><a href=".">todos</a></h1>
 				<input
 					placeholder="What needs to be done?"
 					autofocus
 					class="new-todo"
 					data-todo="new"
+					disabled
 				/>
 			</header>
 			<!-- This section should be hidden by default and shown when there are todos -->
@@ -38,13 +39,13 @@
 				<!-- Remove this if you don't implement routing -->
 				<ul class="filters" data-todo="filters">
 					<li>
-						<a class="selected" href="#/">All</a>
+						<a class="selected" href="#//">All</a>
 					</li>
 					<li>
-						<a href="#/active">Active</a>
+						<a href="#//active">Active</a>
 					</li>
 					<li>
-						<a href="#/completed">Completed</a>
+						<a href="#//completed">Completed</a>
 					</li>
 				</ul>
 				<!-- Hidden if no completed items are left ↓ -->
@@ -54,12 +55,13 @@
 			</footer>
 		</section>
 		<footer class="info">
-			<p>Double-click to edit a todo</p>
-			<p>Created by <a href="https://twitter.com/1Marc">Marc Grabanski</a></p>
+			<p>Double-click to edit a todo | Click the header to create a new todo list</p>
+			<p>Created by <a href="https://twitter.com/1Marc">Marc Grabanski</a> |
+			Collaboration enabled with <a href="https://m-ld.org/">m-ld</a></p>
 			<p>
 				Project on GitHub:
-				<a href="https://github.com/1Marc/todomvc-vanillajs-2022"
-					>Vanilla JS TodoMVC 2022</a
+				<a href="https://github.com/m-ld/m-ld-todomvc-vanillajs"
+					>Vanilla JS TodoMVC with m-ld</a
 				>
 			</p>
 		</footer>

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,6 @@
 import { delegate, getURLHash, insertHTML, replaceHTML } from "./helpers.js";
 import { TodoStore } from "./store.js";
-
-const Todos = new TodoStore("todo-modern-vanillajs");
+import { uuid } from 'https://edge.js.m-ld.org/ext/index.mjs';
 
 const App = {
 	$: {
@@ -9,6 +8,7 @@ const App = {
 		toggleAll: document.querySelector('[data-todo="toggle-all"]'),
 		clear: document.querySelector('[data-todo="clear-completed"]'),
 		list: document.querySelector('[data-todo="list"]'),
+		filters: document.querySelectorAll(`[data-todo="filters"] a`),
 		showMain(show) {
 			document.querySelector('[data-todo="main"]').style.display = show ? "block" : "none";
 		},
@@ -18,8 +18,14 @@ const App = {
 		showClear(show) {
 			App.$.clear.style.display = show ? "block" : "none";
 		},
+		updateFilterHashes() {
+			App.$.filters.forEach((el) => {
+				const {filter} = getURLHash(el.getAttribute('href'));
+				el.setAttribute('href', `#/${App.todos.id}/${filter}`);
+			});
+		},
 		setActiveFilter(filter) {
-			document.querySelectorAll(`[data-todo="filters"] a`).forEach((el) => {
+			App.$.filters.forEach((el) => {
 				if (el.matches(`[href="#/${filter}"]`)) {
 					el.classList.add("selected");
 				} else {
@@ -37,41 +43,48 @@ const App = {
 			);
 		},
 	},
-	init() {
-		Todos.addEventListener("save", App.render);
-		App.filter = getURLHash();
-		window.addEventListener("hashchange", () => {
-			App.filter = getURLHash();
-			App.render();
-		});
+	async init() {
+		function onHashChange() {
+			let {todosId, filter} = getURLHash(document.location.hash);
+			const isNew = !todosId;
+			if (isNew) {
+				todosId = uuid();
+				history.pushState(null, null, `#/${todosId}/${filter}`);
+			}
+			if (App.todos == null || App.todos.id !== todosId) {
+				App.todos?.close();
+				App.todos = new TodoStore(todosId, isNew);
+				App.$.updateFilterHashes();
+				App.todos.addEventListener("save", App.render);
+				App.todos.addEventListener("error", App.error);
+			}
+			App.filter = filter;
+		}
+		window.addEventListener("hashchange", onHashChange);
+		onHashChange();
 		App.$.input.addEventListener("keyup", (e) => {
 			if (e.key === "Enter" && e.target.value.length) {
-				Todos.add({
-					title: e.target.value,
-					completed: false,
-					id: "id_" + Date.now(),
-				});
+				App.todos.add({ title: e.target.value });
 				App.$.input.value = "";
 			}
 		});
-		App.$.toggleAll.addEventListener("click", (e) => {
-			Todos.toggleAll();
+		App.$.toggleAll.addEventListener("click", () => {
+			App.todos.toggleAll();
 		});
-		App.$.clear.addEventListener("click", (e) => {
-			Todos.clearCompleted();
+		App.$.clear.addEventListener("click", () => {
+			App.todos.clearCompleted();
 		});
 		App.bindTodoEvents();
-		App.render();
 	},
 	todoEvent(event, selector, handler) {
 		delegate(App.$.list, selector, event, (e) => {
 			let $el = e.target.closest("[data-id]");
-			handler(Todos.get($el.dataset.id), $el, e);
+			handler(App.todos.get($el.dataset.id), $el, e);
 		});
 	},
 	bindTodoEvents() {
-		App.todoEvent("click", '[data-todo="destroy"]', (todo) => Todos.remove(todo));
-		App.todoEvent("click", '[data-todo="toggle"]', (todo) => Todos.toggle(todo));
+		App.todoEvent("click", '[data-todo="destroy"]', (todo) => App.todos.remove(todo));
+		App.todoEvent("click", '[data-todo="toggle"]', (todo) => App.todos.toggle(todo));
 		App.todoEvent("dblclick", '[data-todo="label"]', (_, $li) => {
 			$li.classList.add("editing");
 			$li.querySelector('[data-todo="edit"]').focus();
@@ -80,13 +93,13 @@ const App = {
 			let $input = $li.querySelector('[data-todo="edit"]');
 			if (e.key === "Enter" && $input.value) {
 				$li.classList.remove("editing");
-				Todos.update({ ...todo, title: $input.value });
+				App.todos.update({ ...todo, title: $input.value });
 			}
 			if (e.key === "Escape") {
 				document.activeElement.blur();
 			}
 		});
-		App.todoEvent("focusout", '[data-todo="edit"]', (todo, $li, e) => {
+		App.todoEvent("focusout", '[data-todo="edit"]', (todo, $li) => {
 			if ($li.classList.contains("editing")) {
 				App.render();
 			}
@@ -94,7 +107,7 @@ const App = {
 	},
 	createTodoItem(todo) {
 		const li = document.createElement("li");
-		li.dataset.id = todo.id;
+		li.dataset.id = todo['@id'];
 		if (todo.completed) {
 			li.classList.add("completed");
 		}
@@ -114,15 +127,24 @@ const App = {
 		return li;
 	},
 	render() {
-		const count = Todos.all().length;
+		const count = App.todos.all().length;
 		App.$.setActiveFilter(App.filter);
-		App.$.list.replaceChildren(...Todos.all(App.filter).map((todo) => App.createTodoItem(todo)));
+		App.$.list.replaceChildren(...App.todos.all(App.filter).map((todo) => App.createTodoItem(todo)));
 		App.$.showMain(count);
 		App.$.showFooter(count);
-		App.$.showClear(Todos.hasCompleted());
-		App.$.toggleAll.checked = Todos.isAllCompleted();
-		App.$.displayCount(Todos.all("active").length);
+		App.$.showClear(App.todos.hasCompleted());
+		App.$.toggleAll.checked = App.todos.isAllCompleted();
+		App.$.displayCount(App.todos.all("active").length);
+		App.$.input.disabled = false;
 	},
+	error(errEvent) {
+		replaceHTML(document.querySelector('.todoapp'), `
+		<header class="header">
+			<h1><a href=".">todos</a></h1>
+			<p>${errEvent.error}</p>
+		</header>
+		`);
+	}
 };
 
-App.init();
+await App.init();

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,4 +1,7 @@
-export const getURLHash = () => document.location.hash.replace(/^#\//, "");
+export const getURLHash = (hash) => {
+	const [todosId, filter] = hash.split('/').slice(1); // Remove hash symbol
+	return {todosId: todosId ?? '', filter: filter ?? ''};
+};
 
 export const delegate = (el, selector, event, handler) => {
 	el.addEventListener(event, (e) => {

--- a/js/store.js
+++ b/js/store.js
@@ -1,19 +1,25 @@
-export const TodoStore = class extends EventTarget {
-	constructor(localStorageKey) {
+import {clone, isReference, updateSubject, uuid} from 'https://edge.js.m-ld.org/ext/index.mjs';
+import {MemoryLevel} from 'https://edge.js.m-ld.org/ext/memory-level.mjs';
+import {IoRemotes} from 'https://edge.js.m-ld.org/ext/socket.io.mjs';
+
+/**
+ * @typedef {object} Todo
+ * @property {string} id
+ * @property {string} title
+ * @property {boolean} completed
+ */
+
+/**
+ * Singleton API for current Todos
+ * @type {TodoStore}
+ */
+export class TodoStore extends EventTarget {
+	constructor(todosId, isNew) {
 		super();
-		this.localStorageKey = localStorageKey;
-		this._readStorage();
-		// handle todos edited in another window
-		window.addEventListener(
-			"storage",
-			() => {
-				this._readStorage();
-				this._save();
-			},
-			false
-		);
+		this.id = todosId;
+		this._readStorage(isNew);
 		// GETTER methods
-		this.get = (id) => this.todos.find((todo) => todo.id === id);
+		this.get = (id) => this.todos.find((todo) => todo['@id'] === id);
 		this.isAllCompleted = () => this.todos.every((todo) => todo.completed);
 		this.hasCompleted = () => this.todos.some((todo) => todo.completed);
 		this.all = (filter) =>
@@ -23,49 +29,89 @@ export const TodoStore = class extends EventTarget {
 				? this.todos.filter((todo) => todo.completed)
 				: this.todos;
 	}
-	_readStorage() {
-		this.todos = JSON.parse(window.localStorage.getItem(this.localStorageKey) || "[]");
+	_handleError = (error) => {
+		this.dispatchEvent(new ErrorEvent('error', {error}));
+	};
+	_readStorage(isNew) {
+		this.todos = [];
+		const loadTodoReferences = async (state) => {
+			await Promise.all(this.todos.map(async (todo, i) => {
+				if (isReference(todo))
+					this.todos[i] = await state.get(todo['@id']);
+			}));
+			console.log(this.todos);
+			this.dispatchEvent(new CustomEvent("save"));
+		};
+		clone(new MemoryLevel, IoRemotes, {
+			'@id': uuid(),
+			'@domain': `${this.id}.todomvc.m-ld.org`,
+			genesis: isNew,
+			io: {uri: 'http://localhost:3001'}
+		}).then(async meld => {
+			this.meld = meld;
+			await meld.status.becomes({ outdated: false });
+			meld.read(async state => {
+				this.todos = (await state.get('todos'))?.['@list'] ?? [];
+				await loadTodoReferences(state);
+			}, async (update, state) => {
+				updateSubject({'@id': 'todos', '@list': this.todos}, update);
+				await loadTodoReferences(state);
+			});
+		}).catch(this._handleError);
 	}
-	_save() {
-		window.localStorage.setItem(
-			this.localStorageKey,
-			JSON.stringify(this.todos)
-		);
-		this.dispatchEvent(new CustomEvent("save"));
+	_save(write) {
+		this.meld.write(write).catch(this._handleError);
 	}
 	// MUTATE methods
-	add(todo) {
-		this.todos.push({
-			title: todo.title,
-			completed: false,
-			id: "id_" + Date.now(),
+	add({ title }) {
+		this._save({
+			'@id': 'todos',
+			'@list': {
+				[this.todos.length]: {
+					title,
+					completed: false,
+					'@id': "id_" + Date.now(),
+				}
+			}
 		});
-		this._save();
 	}
-	remove({ id }) {
-		this.todos = this.todos.filter((todo) => todo.id !== id);
-		this._save();
+	remove({ '@id': id }) {
+		this._save({
+			'@delete': {
+				'@id': 'todos',
+				'@list': {'?': {'@id': id, '?': '?'}}
+			}
+		});
 	}
-	toggle({ id }) {
-		this.todos = this.todos.map((todo) =>
-			todo.id === id ? { ...todo, completed: !todo.completed } : todo
-		);
-		this._save();
+	toggle({ '@id': id, completed }) {
+		this._save({
+			'@update': {'@id': id, completed: !completed}
+		});
 	}
 	clearCompleted() {
 		this.todos = this.todos.filter((todo) => !todo.completed);
-		this._save();
+		this._save({
+			'@delete': {
+				'@id': 'todos',
+				'@list': {'?': {completed: true, '?': '?'}}
+			}
+		});
 	}
-	update(todo) {
-		this.todos = this.todos.map((t) => (t.id === todo.id ? todo : t));
-		this._save();
+	update({ '@id': id, title }) {
+		this._save({
+			'@update': {'@id': id, title}
+		});
 	}
 	toggleAll() {
 		const completed = !this.hasCompleted() || !this.isAllCompleted();
-		this.todos = this.todos.map((todo) => ({ ...todo, completed }));
-		this._save();
+		this._save({
+			// TODO: This ought to be possible with @update
+			'@delete': {'@id': '?id', completed: !completed},
+			'@insert': {'@id': '?id', completed},
+			'@where': {'@id': '?id', completed: !completed}
+		});
 	}
-	revert() {
-		this._save();
+	close() {
+		this.meld?.close().catch(console.error);
 	}
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,1746 @@
 {
-  "name": "todomvc-vanillajs-2022",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "dependencies": {
-        "todomvc-app-css": "^2.0.0"
-      }
-    },
-    "node_modules/todomvc-app-css": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.4.2.tgz",
-      "integrity": "sha512-ViAkQ7ed89rmhFIGRsT36njN+97z8+s3XsJnB8E2IKOq+/SLD/6PtSvmTtiwUcVk39qPcjAc/OyeDys4LoJUVg=="
-    }
-  },
-  "dependencies": {
-    "todomvc-app-css": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.4.2.tgz",
-      "integrity": "sha512-ViAkQ7ed89rmhFIGRsT36njN+97z8+s3XsJnB8E2IKOq+/SLD/6PtSvmTtiwUcVk39qPcjAc/OyeDys4LoJUVg=="
-    }
-  }
+	"name": "m-ld-todomvc-vanillajs",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"dependencies": {
+				"@m-ld/m-ld": "^0.10.0-edge.2",
+				"socket.io": "^4.7.1",
+				"todomvc-app-css": "^2.0.0"
+			}
+		},
+		"node_modules/@ably/msgpack-js": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@ably/msgpack-js/-/msgpack-js-0.4.0.tgz",
+			"integrity": "sha512-IPt/BoiQwCWubqoNik1aw/6M/DleMdrxJOUpSja6xmMRbT2p1TA8oqKWgfZabqzrq8emRNeSl/+4XABPNnW5pQ==",
+			"dependencies": {
+				"bops": "^1.0.1"
+			}
+		},
+		"node_modules/@m-ld/jsonld": {
+			"version": "6.0.1-m-ld.0",
+			"resolved": "https://registry.npmjs.org/@m-ld/jsonld/-/jsonld-6.0.1-m-ld.0.tgz",
+			"integrity": "sha512-b4by+cq+nbXXl501upm/gWLy1FOFtbwEJCgtsN9CsOVx9OpBbgHtyd4z77HJ7iajblrurdeuzQ7AsEthGDQE9Q==",
+			"dependencies": {
+				"canonicalize": "^1.0.1",
+				"lru-cache": "^6.0.0",
+				"rdf-canonize": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@m-ld/m-ld": {
+			"version": "0.10.0-edge.2",
+			"resolved": "https://registry.npmjs.org/@m-ld/m-ld/-/m-ld-0.10.0-edge.2.tgz",
+			"integrity": "sha512-wfh03RQoiPtxBfaXlBwLJlRH8zOmBpwtOs0wf959b12gxviK8z95QiK3t2rsW+3VnGN6bGzbdA+Lq0U7swslxQ==",
+			"dependencies": {
+				"@ably/msgpack-js": "^0.4.0",
+				"@m-ld/jsonld": "^6.0.1-m-ld.0",
+				"@m-ld/m-ld-spec": "^0.7.0-edge.0",
+				"@types/detect-node": "^2.0.0",
+				"@types/lru-cache": "^5.1.1",
+				"@types/requestidlecallback": "^0.3.1",
+				"@types/sha.js": "^2.4.0",
+				"@types/simple-peer": "^9.11.4",
+				"@types/valid-data-url": "^2.0.0",
+				"abstract-level": "^1.0.3",
+				"asynciterator": "^3.2.0",
+				"cuid": "^2.1.8",
+				"fflate": "^0.8.0",
+				"json-rql": "^0.6.2",
+				"loglevel": "^1.7.1",
+				"lru-cache": "^6.0.0",
+				"marky": "^1.2.1",
+				"mqtt-pattern": "^1.2.0",
+				"quadstore": "^12.0.1",
+				"quadstore-comunica": "^3.1.0",
+				"queue-microtask": "^1.2.3",
+				"rdf-data-factory": "^1.0.4",
+				"reflect-metadata": "^0.1.13",
+				"rx-flowable": "^0.1.0",
+				"rxjs": "^7.2.0",
+				"sha.js": "^2.4.11",
+				"sparqlalgebrajs": "^4.0.3",
+				"valid-data-url": "^4.0.0"
+			},
+			"peerDependencies": {
+				"@peculiar/webcrypto": "1",
+				"ably": "1",
+				"async-mqtt": "2",
+				"simple-peer": "9",
+				"socket.io": "4",
+				"socket.io-client": "4"
+			},
+			"peerDependenciesMeta": {
+				"@peculiar/webcrypto": {
+					"optional": true
+				},
+				"ably": {
+					"optional": true
+				},
+				"async-mqtt": {
+					"optional": true
+				},
+				"simple-peer": {
+					"optional": true
+				},
+				"socket.io": {
+					"optional": true
+				},
+				"socket.io-client": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@m-ld/m-ld-spec": {
+			"version": "0.7.0-edge.0",
+			"resolved": "https://registry.npmjs.org/@m-ld/m-ld-spec/-/m-ld-spec-0.7.0-edge.0.tgz",
+			"integrity": "sha512-7vp0VNg73UWI40NftCToT/OKfddzrU3s93JUFizPfija6fLlMAhaotB3fRT6rTrCRJqlvOi34OY4XtwVgiarbg==",
+			"dependencies": {
+				"jasmine": "^4.4.0",
+				"json-rql": "^0.6.2",
+				"node-fetch": "^2.6.7",
+				"rxjs": "^7.2.0"
+			}
+		},
+		"node_modules/@rdfjs/types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
+			"integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@socket.io/component-emitter": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+		},
+		"node_modules/@types/cookie": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+		},
+		"node_modules/@types/cors": {
+			"version": "2.8.13",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+			"integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/detect-node": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/detect-node/-/detect-node-2.0.0.tgz",
+			"integrity": "sha512-+BozjlbPTACYITf1PWf62HLtDV79HbmZosUN1mv1gGrnjDCRwBXkDKka1sf6YQJvspmfPXVcy+X6tFW62KteeQ=="
+		},
+		"node_modules/@types/jsonld": {
+			"version": "1.5.9",
+			"resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.9.tgz",
+			"integrity": "sha512-K76ImkErPYL2wGPZpNFSKp6wE+h/APecZLJrU7UfDaGqt/f+D9Rrg1aR7VdRrQ6k5DUNRZ2vn9yACwmpOr9QcA=="
+		},
+		"node_modules/@types/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+		},
+		"node_modules/@types/node": {
+			"version": "20.3.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+			"integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw=="
+		},
+		"node_modules/@types/rdf-js": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
+			"integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
+			"deprecated": "This is a stub types definition. rdf-js provides its own type definitions, so you do not need this installed.",
+			"dependencies": {
+				"rdf-js": "*"
+			}
+		},
+		"node_modules/@types/requestidlecallback": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@types/requestidlecallback/-/requestidlecallback-0.3.5.tgz",
+			"integrity": "sha512-Uh49VrVTPfU0y/qIvXXYuRmd/sKLfVgQWZU1t8FWH22AIJyQbCei1aSmXdMDAijwGUFhBDpJmksiHEDsfiE/cg=="
+		},
+		"node_modules/@types/sha.js": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/sha.js/-/sha.js-2.4.0.tgz",
+			"integrity": "sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/simple-peer": {
+			"version": "9.11.5",
+			"resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.5.tgz",
+			"integrity": "sha512-haXgWcAa3Y3Sn+T8lzkE4ErQUpYzhW6Cz2lh00RhQTyWt+xZ3s87wJPztUxlqSdFRqGhe2MQIBd0XsyHP3No4w==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/sparqljs": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.4.tgz",
+			"integrity": "sha512-0MvCTEfveYJDkI91olLcDf/F3wMMbsxwNxiNZeglt4tbIFULd9pRpcacj1MuA+acFDkTnPXS9L7OqZNn/W1MAg==",
+			"dependencies": {
+				"rdf-js": "^4.0.2"
+			}
+		},
+		"node_modules/@types/valid-data-url": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/valid-data-url/-/valid-data-url-2.0.0.tgz",
+			"integrity": "sha512-96NadqQC1BDUJQYjjwYVTo6XaBuiFQo2vfvsTLTlHxg8RbjfMNTHeD5ErRsz4rHdA4rDChFjLB2rCayoulPHmQ=="
+		},
+		"node_modules/abstract-level": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
+			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"catering": "^2.1.0",
+				"is-buffer": "^2.0.5",
+				"level-supports": "^4.0.0",
+				"level-transcoder": "^1.0.1",
+				"module-error": "^1.0.1",
+				"queue-microtask": "^1.2.3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/asynciterator": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.8.0.tgz",
+			"integrity": "sha512-bD34LqKHJnkB77MHjL3hOAUOcy9dbB+3lHvL+EiJpD3k2Nyq3i1dCk5adMisB2rwlrHVu/+XRhOdPZL9hzpsfw=="
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/base64-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
+			"integrity": "sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg==",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/base64id": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+			"engines": {
+				"node": "^4.5.0 || >= 5.9"
+			}
+		},
+		"node_modules/bops": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bops/-/bops-1.0.1.tgz",
+			"integrity": "sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==",
+			"dependencies": {
+				"base64-js": "1.0.2",
+				"to-utf8": "0.0.1"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/buffer/node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/canonicalize": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+			"integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
+		},
+		"node_modules/catering": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+		},
+		"node_modules/cookie": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/cuid": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+			"integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==",
+			"deprecated": "Cuid and other k-sortable and non-cryptographic ids (Ulid, ObjectId, KSUID, all UUIDs) are all insecure. Use @paralleldrive/cuid2 instead."
+		},
+		"node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/engine.io": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.1.tgz",
+			"integrity": "sha512-mGqhI+D7YxS9KJMppR6Iuo37Ed3abhU8NdfgSvJSDUafQutrN+sPTncJYTyM9+tkhSmWodKtVYGPPHyXJEwEQA==",
+			"dependencies": {
+				"@types/cookie": "^0.4.1",
+				"@types/cors": "^2.8.12",
+				"@types/node": ">=10.0.0",
+				"accepts": "~1.3.4",
+				"base64id": "2.0.0",
+				"cookie": "~0.4.1",
+				"cors": "~2.8.5",
+				"debug": "~4.3.1",
+				"engine.io-parser": "~5.1.0",
+				"ws": "~8.11.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/engine.io-parser": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.1.0.tgz",
+			"integrity": "sha512-enySgNiK5tyZFynt3z7iqBR+Bto9EVVVvDFuTT0ioHCGbzirZVGDGiQjZzEp8hWl6hd5FSVytJGuScX1C1C35w==",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
+		"node_modules/fflate": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+			"integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/jasmine": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.6.0.tgz",
+			"integrity": "sha512-iq7HQ5M8ydNUspjd9vbFW9Lu+6lQ1QLDIqjl0WysEllF5EJZy8XaUyNlhCJVwOx2YFzqTtARWbS56F/f0PzRFw==",
+			"dependencies": {
+				"glob": "^7.1.6",
+				"jasmine-core": "^4.6.0"
+			},
+			"bin": {
+				"jasmine": "bin/jasmine.js"
+			}
+		},
+		"node_modules/jasmine-core": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.0.tgz",
+			"integrity": "sha512-O236+gd0ZXS8YAjFx8xKaJ94/erqUliEkJTDedyE7iHvv4ZVqi+q+8acJxu05/WJDKm512EUNn809In37nWlAQ=="
+		},
+		"node_modules/js-sorted-set": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/js-sorted-set/-/js-sorted-set-0.7.0.tgz",
+			"integrity": "sha512-NGTSMeoLNYR2BoTLhQ6w+u7Ox4PO34omb/0OBCy4gyedWeXolMGv948Ato0/Of6tfxsAjeySDymCkAj93/xkeA=="
+		},
+		"node_modules/json-rql": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/json-rql/-/json-rql-0.6.2.tgz",
+			"integrity": "sha512-dqLgj4wcaP39gf+NPP79y/9FCknyo9RWvWgGtFEnyqeDihyFGa1X4/UP2IeVVmvp68+9NCO/3w/JwVvKPX2W6Q==",
+			"dependencies": {
+				"@types/jsonld": "^1.5.2"
+			}
+		},
+		"node_modules/level-supports": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/level-transcoder": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"module-error": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/loglevel": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+			"integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+			"engines": {
+				"node": ">= 0.6.0"
+			},
+			"funding": {
+				"type": "tidelift",
+				"url": "https://tidelift.com/funding/github/npm/loglevel"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/marky": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
+			"integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q=="
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/module-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/mqtt-match": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mqtt-match/-/mqtt-match-1.0.3.tgz",
+			"integrity": "sha512-nfeAp+chyjVeIvvrgMhQCfDAIVp/zXX8rtxHQwuAWuapqAdFs1F0kIekG445ps3xs/qFPK6l2xRlAyiqqwbmrQ=="
+		},
+		"node_modules/mqtt-pattern": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mqtt-pattern/-/mqtt-pattern-1.2.0.tgz",
+			"integrity": "sha512-5tvJTrMXcvAWRc4J+YW0pnZOLi20yXFX1R7cjB0291X9aRFPyO+5vbh/kHVwUlNPfJuwijcvrd/AmwDLe1021w==",
+			"dependencies": {
+				"mqtt-match": "^1.0.2"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+			"integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/quadstore": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/quadstore/-/quadstore-12.0.1.tgz",
+			"integrity": "sha512-S0Ayv7kAX9ZU4N8Lwob5BOhKSyFEl3QIW8JSp9GkZ6ApSHj/ha0ceHLptMwO8vnf/l/CSe9RXUikkLL8MPmCMA==",
+			"dependencies": {
+				"@types/rdf-js": "^4.0.1",
+				"abstract-level": "^1.0.3",
+				"asynciterator": "^3.8.0",
+				"js-sorted-set": "^0.7.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/quadstore-comunica": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/quadstore-comunica/-/quadstore-comunica-3.1.0.tgz",
+			"integrity": "sha512-5KaflJ3yxKhBHyl6ptTyBcmzJiaXhXNorjPGpleNk3UKEh0RYlna4I2YlGdFQab7R6UzxkDwlJggXXEIS+yikA==",
+			"dependencies": {
+				"@rdfjs/types": "^1.1.0",
+				"sparqlalgebrajs": "^4.0.5",
+				"sparqljs": "^3.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"asynciterator": "^3.7.0",
+				"quadstore": "^12.0.0-alpha.1"
+			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/rdf-canonize": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+			"integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+			"dependencies": {
+				"setimmediate": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/rdf-data-factory": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+			"integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
+			"dependencies": {
+				"@rdfjs/types": "*"
+			}
+		},
+		"node_modules/rdf-isomorphic": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz",
+			"integrity": "sha512-6uIhsXTVp2AtO6f41PdnRV5xZsa0zVZQDTBdn0br+DZuFf5M/YD+T6m8hKDUnALI6nFL/IujTMLgEs20MlNidQ==",
+			"dependencies": {
+				"@rdfjs/types": "*",
+				"hash.js": "^1.1.7",
+				"rdf-string": "^1.6.0",
+				"rdf-terms": "^1.7.0"
+			}
+		},
+		"node_modules/rdf-js": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+			"integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+			"dependencies": {
+				"@rdfjs/types": "*"
+			}
+		},
+		"node_modules/rdf-string": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
+			"integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
+			"dependencies": {
+				"@rdfjs/types": "*",
+				"rdf-data-factory": "^1.1.0"
+			}
+		},
+		"node_modules/rdf-terms": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
+			"integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
+			"dependencies": {
+				"@rdfjs/types": "*",
+				"rdf-data-factory": "^1.1.0",
+				"rdf-string": "^1.6.0"
+			}
+		},
+		"node_modules/reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
+		"node_modules/rx-flowable": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/rx-flowable/-/rx-flowable-0.1.2.tgz",
+			"integrity": "sha512-2N6ifjuNyCqQdTpgyXIy3V/F18uKGUdODId5rw5UO3cHihh5C6uYI+Bcz+IF+YTtXr7yPgsOC3iaeAWPAgOeWA==",
+			"dependencies": {
+				"rxjs": "^7.5.1"
+			}
+		},
+		"node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+		},
+		"node_modules/sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			},
+			"bin": {
+				"sha.js": "bin.js"
+			}
+		},
+		"node_modules/socket.io": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.1.tgz",
+			"integrity": "sha512-W+utHys2w//dhFjy7iQQu9sGd3eokCjGbl2r59tyLqNiJJBdIebn3GAKEXBr3osqHTObJi2die/25bCx2zsaaw==",
+			"dependencies": {
+				"accepts": "~1.3.4",
+				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
+				"debug": "~4.3.2",
+				"engine.io": "~6.5.0",
+				"socket.io-adapter": "~2.5.2",
+				"socket.io-parser": "~4.2.4"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/socket.io-adapter": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+			"dependencies": {
+				"ws": "~8.11.0"
+			}
+		},
+		"node_modules/socket.io-parser": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+			"integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.3.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/sparqlalgebrajs": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.2.0.tgz",
+			"integrity": "sha512-tdlJdrvgQqgx9zubcl9iiyCxMOp4qRT2fs1Sne8X35QTm1Pj2ulB+gGEHunJJnw5FW7Uhtmw7J3px0sCmgJSbw==",
+			"dependencies": {
+				"@rdfjs/types": "*",
+				"@types/sparqljs": "^3.1.3",
+				"fast-deep-equal": "^3.1.3",
+				"minimist": "^1.2.6",
+				"rdf-data-factory": "^1.1.0",
+				"rdf-isomorphic": "^1.3.0",
+				"rdf-string": "^1.6.0",
+				"rdf-terms": "^1.10.0",
+				"sparqljs": "^3.7.1"
+			},
+			"bin": {
+				"sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+			}
+		},
+		"node_modules/sparqljs": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.1.tgz",
+			"integrity": "sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==",
+			"dependencies": {
+				"rdf-data-factory": "^1.1.2"
+			},
+			"bin": {
+				"sparqljs": "bin/sparql-to-json"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/to-utf8": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+			"integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ=="
+		},
+		"node_modules/todomvc-app-css": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.4.2.tgz",
+			"integrity": "sha512-ViAkQ7ed89rmhFIGRsT36njN+97z8+s3XsJnB8E2IKOq+/SLD/6PtSvmTtiwUcVk39qPcjAc/OyeDys4LoJUVg=="
+		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
+		"node_modules/tslib": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+			"integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+		},
+		"node_modules/valid-data-url": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.1.tgz",
+			"integrity": "sha512-t0oA6VCnlQ/MPKP/Ie9ZD3biEpB2JTxK1Hx4KC72RbhubL9HsXznoBn228UQTazL7cPvsY36bhzt3fk424TjyA==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"node_modules/ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		}
+	},
+	"dependencies": {
+		"@ably/msgpack-js": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@ably/msgpack-js/-/msgpack-js-0.4.0.tgz",
+			"integrity": "sha512-IPt/BoiQwCWubqoNik1aw/6M/DleMdrxJOUpSja6xmMRbT2p1TA8oqKWgfZabqzrq8emRNeSl/+4XABPNnW5pQ==",
+			"requires": {
+				"bops": "^1.0.1"
+			}
+		},
+		"@m-ld/jsonld": {
+			"version": "6.0.1-m-ld.0",
+			"resolved": "https://registry.npmjs.org/@m-ld/jsonld/-/jsonld-6.0.1-m-ld.0.tgz",
+			"integrity": "sha512-b4by+cq+nbXXl501upm/gWLy1FOFtbwEJCgtsN9CsOVx9OpBbgHtyd4z77HJ7iajblrurdeuzQ7AsEthGDQE9Q==",
+			"requires": {
+				"canonicalize": "^1.0.1",
+				"lru-cache": "^6.0.0",
+				"rdf-canonize": "^3.0.0"
+			}
+		},
+		"@m-ld/m-ld": {
+			"version": "0.10.0-edge.2",
+			"resolved": "https://registry.npmjs.org/@m-ld/m-ld/-/m-ld-0.10.0-edge.2.tgz",
+			"integrity": "sha512-wfh03RQoiPtxBfaXlBwLJlRH8zOmBpwtOs0wf959b12gxviK8z95QiK3t2rsW+3VnGN6bGzbdA+Lq0U7swslxQ==",
+			"requires": {
+				"@ably/msgpack-js": "^0.4.0",
+				"@m-ld/jsonld": "^6.0.1-m-ld.0",
+				"@m-ld/m-ld-spec": "^0.7.0-edge.0",
+				"@types/detect-node": "^2.0.0",
+				"@types/lru-cache": "^5.1.1",
+				"@types/requestidlecallback": "^0.3.1",
+				"@types/sha.js": "^2.4.0",
+				"@types/simple-peer": "^9.11.4",
+				"@types/valid-data-url": "^2.0.0",
+				"abstract-level": "^1.0.3",
+				"asynciterator": "^3.2.0",
+				"cuid": "^2.1.8",
+				"fflate": "^0.8.0",
+				"json-rql": "^0.6.2",
+				"loglevel": "^1.7.1",
+				"lru-cache": "^6.0.0",
+				"marky": "^1.2.1",
+				"mqtt-pattern": "^1.2.0",
+				"quadstore": "^12.0.1",
+				"quadstore-comunica": "^3.1.0",
+				"queue-microtask": "^1.2.3",
+				"rdf-data-factory": "^1.0.4",
+				"reflect-metadata": "^0.1.13",
+				"rx-flowable": "^0.1.0",
+				"rxjs": "^7.2.0",
+				"sha.js": "^2.4.11",
+				"sparqlalgebrajs": "^4.0.3",
+				"valid-data-url": "^4.0.0"
+			}
+		},
+		"@m-ld/m-ld-spec": {
+			"version": "0.7.0-edge.0",
+			"resolved": "https://registry.npmjs.org/@m-ld/m-ld-spec/-/m-ld-spec-0.7.0-edge.0.tgz",
+			"integrity": "sha512-7vp0VNg73UWI40NftCToT/OKfddzrU3s93JUFizPfija6fLlMAhaotB3fRT6rTrCRJqlvOi34OY4XtwVgiarbg==",
+			"requires": {
+				"jasmine": "^4.4.0",
+				"json-rql": "^0.6.2",
+				"node-fetch": "^2.6.7",
+				"rxjs": "^7.2.0"
+			}
+		},
+		"@rdfjs/types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
+			"integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@socket.io/component-emitter": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+		},
+		"@types/cookie": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+		},
+		"@types/cors": {
+			"version": "2.8.13",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+			"integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/detect-node": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/detect-node/-/detect-node-2.0.0.tgz",
+			"integrity": "sha512-+BozjlbPTACYITf1PWf62HLtDV79HbmZosUN1mv1gGrnjDCRwBXkDKka1sf6YQJvspmfPXVcy+X6tFW62KteeQ=="
+		},
+		"@types/jsonld": {
+			"version": "1.5.9",
+			"resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.9.tgz",
+			"integrity": "sha512-K76ImkErPYL2wGPZpNFSKp6wE+h/APecZLJrU7UfDaGqt/f+D9Rrg1aR7VdRrQ6k5DUNRZ2vn9yACwmpOr9QcA=="
+		},
+		"@types/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+		},
+		"@types/node": {
+			"version": "20.3.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+			"integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw=="
+		},
+		"@types/rdf-js": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
+			"integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
+			"requires": {
+				"rdf-js": "*"
+			}
+		},
+		"@types/requestidlecallback": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@types/requestidlecallback/-/requestidlecallback-0.3.5.tgz",
+			"integrity": "sha512-Uh49VrVTPfU0y/qIvXXYuRmd/sKLfVgQWZU1t8FWH22AIJyQbCei1aSmXdMDAijwGUFhBDpJmksiHEDsfiE/cg=="
+		},
+		"@types/sha.js": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/sha.js/-/sha.js-2.4.0.tgz",
+			"integrity": "sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/simple-peer": {
+			"version": "9.11.5",
+			"resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.5.tgz",
+			"integrity": "sha512-haXgWcAa3Y3Sn+T8lzkE4ErQUpYzhW6Cz2lh00RhQTyWt+xZ3s87wJPztUxlqSdFRqGhe2MQIBd0XsyHP3No4w==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/sparqljs": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.4.tgz",
+			"integrity": "sha512-0MvCTEfveYJDkI91olLcDf/F3wMMbsxwNxiNZeglt4tbIFULd9pRpcacj1MuA+acFDkTnPXS9L7OqZNn/W1MAg==",
+			"requires": {
+				"rdf-js": "^4.0.2"
+			}
+		},
+		"@types/valid-data-url": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/valid-data-url/-/valid-data-url-2.0.0.tgz",
+			"integrity": "sha512-96NadqQC1BDUJQYjjwYVTo6XaBuiFQo2vfvsTLTlHxg8RbjfMNTHeD5ErRsz4rHdA4rDChFjLB2rCayoulPHmQ=="
+		},
+		"abstract-level": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
+			"integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
+			"requires": {
+				"buffer": "^6.0.3",
+				"catering": "^2.1.0",
+				"is-buffer": "^2.0.5",
+				"level-supports": "^4.0.0",
+				"level-transcoder": "^1.0.1",
+				"module-error": "^1.0.1",
+				"queue-microtask": "^1.2.3"
+			}
+		},
+		"accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"requires": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			}
+		},
+		"asynciterator": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.8.0.tgz",
+			"integrity": "sha512-bD34LqKHJnkB77MHjL3hOAUOcy9dbB+3lHvL+EiJpD3k2Nyq3i1dCk5adMisB2rwlrHVu/+XRhOdPZL9hzpsfw=="
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"base64-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
+			"integrity": "sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg=="
+		},
+		"base64id": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
+		},
+		"bops": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bops/-/bops-1.0.1.tgz",
+			"integrity": "sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==",
+			"requires": {
+				"base64-js": "1.0.2",
+				"to-utf8": "0.0.1"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			},
+			"dependencies": {
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
+			}
+		},
+		"canonicalize": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+			"integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
+		},
+		"catering": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+		},
+		"cookie": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+		},
+		"cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"requires": {
+				"object-assign": "^4",
+				"vary": "^1"
+			}
+		},
+		"cuid": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+			"integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
+		},
+		"debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"engine.io": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.1.tgz",
+			"integrity": "sha512-mGqhI+D7YxS9KJMppR6Iuo37Ed3abhU8NdfgSvJSDUafQutrN+sPTncJYTyM9+tkhSmWodKtVYGPPHyXJEwEQA==",
+			"requires": {
+				"@types/cookie": "^0.4.1",
+				"@types/cors": "^2.8.12",
+				"@types/node": ">=10.0.0",
+				"accepts": "~1.3.4",
+				"base64id": "2.0.0",
+				"cookie": "~0.4.1",
+				"cors": "~2.8.5",
+				"debug": "~4.3.1",
+				"engine.io-parser": "~5.1.0",
+				"ws": "~8.11.0"
+			}
+		},
+		"engine.io-parser": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.1.0.tgz",
+			"integrity": "sha512-enySgNiK5tyZFynt3z7iqBR+Bto9EVVVvDFuTT0ioHCGbzirZVGDGiQjZzEp8hWl6hd5FSVytJGuScX1C1C35w=="
+		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
+		"fflate": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+			"integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+		},
+		"glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+		},
+		"jasmine": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.6.0.tgz",
+			"integrity": "sha512-iq7HQ5M8ydNUspjd9vbFW9Lu+6lQ1QLDIqjl0WysEllF5EJZy8XaUyNlhCJVwOx2YFzqTtARWbS56F/f0PzRFw==",
+			"requires": {
+				"glob": "^7.1.6",
+				"jasmine-core": "^4.6.0"
+			}
+		},
+		"jasmine-core": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.0.tgz",
+			"integrity": "sha512-O236+gd0ZXS8YAjFx8xKaJ94/erqUliEkJTDedyE7iHvv4ZVqi+q+8acJxu05/WJDKm512EUNn809In37nWlAQ=="
+		},
+		"js-sorted-set": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/js-sorted-set/-/js-sorted-set-0.7.0.tgz",
+			"integrity": "sha512-NGTSMeoLNYR2BoTLhQ6w+u7Ox4PO34omb/0OBCy4gyedWeXolMGv948Ato0/Of6tfxsAjeySDymCkAj93/xkeA=="
+		},
+		"json-rql": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/json-rql/-/json-rql-0.6.2.tgz",
+			"integrity": "sha512-dqLgj4wcaP39gf+NPP79y/9FCknyo9RWvWgGtFEnyqeDihyFGa1X4/UP2IeVVmvp68+9NCO/3w/JwVvKPX2W6Q==",
+			"requires": {
+				"@types/jsonld": "^1.5.2"
+			}
+		},
+		"level-supports": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA=="
+		},
+		"level-transcoder": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+			"requires": {
+				"buffer": "^6.0.3",
+				"module-error": "^1.0.1"
+			}
+		},
+		"loglevel": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+			"integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg=="
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"marky": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
+			"integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q=="
+		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"requires": {
+				"mime-db": "1.52.0"
+			}
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+		},
+		"module-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA=="
+		},
+		"mqtt-match": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mqtt-match/-/mqtt-match-1.0.3.tgz",
+			"integrity": "sha512-nfeAp+chyjVeIvvrgMhQCfDAIVp/zXX8rtxHQwuAWuapqAdFs1F0kIekG445ps3xs/qFPK6l2xRlAyiqqwbmrQ=="
+		},
+		"mqtt-pattern": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mqtt-pattern/-/mqtt-pattern-1.2.0.tgz",
+			"integrity": "sha512-5tvJTrMXcvAWRc4J+YW0pnZOLi20yXFX1R7cjB0291X9aRFPyO+5vbh/kHVwUlNPfJuwijcvrd/AmwDLe1021w==",
+			"requires": {
+				"mqtt-match": "^1.0.2"
+			}
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+		},
+		"node-fetch": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+			"integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+		},
+		"quadstore": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/quadstore/-/quadstore-12.0.1.tgz",
+			"integrity": "sha512-S0Ayv7kAX9ZU4N8Lwob5BOhKSyFEl3QIW8JSp9GkZ6ApSHj/ha0ceHLptMwO8vnf/l/CSe9RXUikkLL8MPmCMA==",
+			"requires": {
+				"@types/rdf-js": "^4.0.1",
+				"abstract-level": "^1.0.3",
+				"asynciterator": "^3.8.0",
+				"js-sorted-set": "^0.7.0"
+			}
+		},
+		"quadstore-comunica": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/quadstore-comunica/-/quadstore-comunica-3.1.0.tgz",
+			"integrity": "sha512-5KaflJ3yxKhBHyl6ptTyBcmzJiaXhXNorjPGpleNk3UKEh0RYlna4I2YlGdFQab7R6UzxkDwlJggXXEIS+yikA==",
+			"requires": {
+				"@rdfjs/types": "^1.1.0",
+				"sparqlalgebrajs": "^4.0.5",
+				"sparqljs": "^3.6.2"
+			}
+		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+		},
+		"rdf-canonize": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+			"integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+			"requires": {
+				"setimmediate": "^1.0.5"
+			}
+		},
+		"rdf-data-factory": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+			"integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
+			"requires": {
+				"@rdfjs/types": "*"
+			}
+		},
+		"rdf-isomorphic": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz",
+			"integrity": "sha512-6uIhsXTVp2AtO6f41PdnRV5xZsa0zVZQDTBdn0br+DZuFf5M/YD+T6m8hKDUnALI6nFL/IujTMLgEs20MlNidQ==",
+			"requires": {
+				"@rdfjs/types": "*",
+				"hash.js": "^1.1.7",
+				"rdf-string": "^1.6.0",
+				"rdf-terms": "^1.7.0"
+			}
+		},
+		"rdf-js": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+			"integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+			"requires": {
+				"@rdfjs/types": "*"
+			}
+		},
+		"rdf-string": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
+			"integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
+			"requires": {
+				"@rdfjs/types": "*",
+				"rdf-data-factory": "^1.1.0"
+			}
+		},
+		"rdf-terms": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
+			"integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
+			"requires": {
+				"@rdfjs/types": "*",
+				"rdf-data-factory": "^1.1.0",
+				"rdf-string": "^1.6.0"
+			}
+		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
+		"rx-flowable": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/rx-flowable/-/rx-flowable-0.1.2.tgz",
+			"integrity": "sha512-2N6ifjuNyCqQdTpgyXIy3V/F18uKGUdODId5rw5UO3cHihh5C6uYI+Bcz+IF+YTtXr7yPgsOC3iaeAWPAgOeWA==",
+			"requires": {
+				"rxjs": "^7.5.1"
+			}
+		},
+		"rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"requires": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"socket.io": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.1.tgz",
+			"integrity": "sha512-W+utHys2w//dhFjy7iQQu9sGd3eokCjGbl2r59tyLqNiJJBdIebn3GAKEXBr3osqHTObJi2die/25bCx2zsaaw==",
+			"requires": {
+				"accepts": "~1.3.4",
+				"base64id": "~2.0.0",
+				"cors": "~2.8.5",
+				"debug": "~4.3.2",
+				"engine.io": "~6.5.0",
+				"socket.io-adapter": "~2.5.2",
+				"socket.io-parser": "~4.2.4"
+			}
+		},
+		"socket.io-adapter": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+			"integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+			"requires": {
+				"ws": "~8.11.0"
+			}
+		},
+		"socket.io-parser": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+			"integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+			"requires": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.3.1"
+			}
+		},
+		"sparqlalgebrajs": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.2.0.tgz",
+			"integrity": "sha512-tdlJdrvgQqgx9zubcl9iiyCxMOp4qRT2fs1Sne8X35QTm1Pj2ulB+gGEHunJJnw5FW7Uhtmw7J3px0sCmgJSbw==",
+			"requires": {
+				"@rdfjs/types": "*",
+				"@types/sparqljs": "^3.1.3",
+				"fast-deep-equal": "^3.1.3",
+				"minimist": "^1.2.6",
+				"rdf-data-factory": "^1.1.0",
+				"rdf-isomorphic": "^1.3.0",
+				"rdf-string": "^1.6.0",
+				"rdf-terms": "^1.10.0",
+				"sparqljs": "^3.7.1"
+			}
+		},
+		"sparqljs": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.1.tgz",
+			"integrity": "sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==",
+			"requires": {
+				"rdf-data-factory": "^1.1.2"
+			}
+		},
+		"to-utf8": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+			"integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ=="
+		},
+		"todomvc-app-css": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.4.2.tgz",
+			"integrity": "sha512-ViAkQ7ed89rmhFIGRsT36njN+97z8+s3XsJnB8E2IKOq+/SLD/6PtSvmTtiwUcVk39qPcjAc/OyeDys4LoJUVg=="
+		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
+		"tslib": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+			"integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+		},
+		"valid-data-url": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.1.tgz",
+			"integrity": "sha512-t0oA6VCnlQ/MPKP/Ie9ZD3biEpB2JTxK1Hx4KC72RbhubL9HsXznoBn228UQTazL7cPvsY36bhzt3fk424TjyA=="
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+		},
+		"webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+		},
+		"whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"requires": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"requires": {}
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
 		"format": "npx prettier --write ."
 	},
 	"dependencies": {
+		"@m-ld/m-ld": "^0.10.0-edge.2",
+		"socket.io": "^4.7.1",
 		"todomvc-app-css": "^2.0.0"
 	},
 	"dependenciesComments": {

--- a/readme.md
+++ b/readme.md
@@ -1,69 +1,21 @@
-# TodoMVC App Written in Modern Vanilla JS
+# Collaborative TodoMVC App in Vanilla JS
 
-It seems straightforward to build reasonably complex things using only modern JavaScript these days! We can take advantage of most newer features without hacks or polyfills.
+This is a [vanilla Javascript implementation of TodoMVC](https://frontendmasters.com/blog/vanilla-javascript-todomvc/), with collaboration enabled using [**m-ld**](https://m-ld.org/).
 
-Here's my Vanilla JavaScript implementation:
+> It seems straightforward to build reasonably complex things using only modern JavaScript these days! We can take advantage of most newer features without hacks or polyfills.
 
-- ~200 lines of code total (compared to the official vanilla JS TodoMVC from 6 years ago was 900+ LOC)
-- No build tools
-- JavaScript modules
+– [Marc Grabanski](https://twitter.com/1Marc)
 
-<a href="https://1marc.github.io/modern-todomvc-vanillajs/" target="_new">View the working example on GitHub pages</a>
+## Trying It Out
 
-Criticism, PRs, and feedback are welcome!
+1. `git clone`
+2. `npm install`
+3. `node relay.mjs` (starts the message relay server on localhost)
 
-## Project Blog Post:
-
-[<img alt="Modern Vanilla JavaScript TodoMVC in 2022 Article" width="750" src="https://static.frontendmasters.com/assets/blog/2022/vanilla-javascript-todomvc.jpg" />](https://frontendmasters.com/blog/vanilla-javascript-todomvc/)
-
-# Additional Examples
-
-## Initial Code
-
-The initial version came together in only 60 minutes, then ~30 min of refactoring: [see the commit here](https://github.com/1Marc/modern-todomvc-vanillajs/tree/fb3c61ed104c440f0c29e3a074b6777c791aa2f6)
-
-How quick it was to get working was what initially got me pumped about all of the progress in the core JavaScript language.
-
-## App Architecture
-
-People were concerned about the scalability of apps like this since there are no components, and it's all one App. So I extracted the TodoList and App components and wired the components together on the app-architecture branch.
-
-Branch: https://github.com/1Marc/modern-todomvc-vanillajs/tree/app-architecture
-
-Note: I realize it is silly to say the word "scalable" in the context of a todo app, but this should be looked at as a blueprint for building something more extensive. I plan to make more ambitious examples in the future to show what's possible.
-
-## More Granular & Performant DOM Updates for Large Lists
-
-Since I'm rendering everything on every update of the model from scratch, this can cause performance issues on long lists.
-
-Here's a branch sending specific events with context from the model so we can make DOM updates more selectively as we need them ([see code diff](https://github.com/1Marc/modern-todomvc-vanillajs/commit/fc89da1a6bd15489d5256575a4e193e11efd8d43)).
-
-Branch: https://github.com/1Marc/modern-todomvc-vanillajs/tree/performant-rendering
-
-## More Performant DOM Updates for Large Lists with lit-html (Plus animations!)
-
-We can achieve the same performant DOM updates with far less code by adopting lit-html using the repeat directive ([see code diff](https://github.com/1Marc/modern-todomvc-vanillajs/commit/ef86a73166029991dc88c649f7ec4931a2a96c86)).
-
-Branch: https://github.com/1Marc/modern-todomvc-vanillajs/tree/animation-lithtml
-
-## TypeScript
-
-Here's the code base with TypeScript: https://github.com/1Marc/modern-todomvc-vanillaj/tree/typescript
-
-## TypeScript + ESLint
-
-Here's the code base with TypeScript and linting with ESLint: https://github.com/1Marc/modern-todomvc-vanillajs/tree/typescript-eslint
-
-# Example UI Components Using this Architecture
-
-[Vanilla JavaScript View Switcher Based on Hash Change](https://codepen.io/1Marc/pen/poLmXZR)
-
-<a href="https://codepen.io/1Marc/pen/poLmXZR"><img src="https://user-images.githubusercontent.com/19269/189225506-1c1838e1-5b2a-408b-802a-dfe71b2f703c.png" width="500" /></a>
-
-[Vanilla JavaScript Countdown Clock](https://codepen.io/1Marc/pen/bGvPRdy)
-
-<a href="https://codepen.io/1Marc/pen/bGvPRdy"><img src="https://user-images.githubusercontent.com/19269/189225317-bb2ce1fb-a734-4193-beb1-670b5d6fbb04.png" width="500" /></a>
+   🚧 This will shortly be replaced with a default online gateway
+4. Navigate to `index.html`
+5. When ready, copy the URL and paste it into another browser
 
 ## License
 
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />This <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/InteractiveResource" rel="dct:type">work</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://sindresorhus.com" property="cc:attributionName" rel="cc:attributionURL">TasteJS</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/deed.en_US">Creative Commons Attribution 4.0 International License</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />

--- a/relay.mjs
+++ b/relay.mjs
@@ -1,0 +1,10 @@
+import { IoRemotesService } from '@m-ld/m-ld/ext/socket.io-server';
+import { Server } from 'socket.io';
+
+const io = new Server(3001, {
+	cors: { origin: "*", methods: ["GET", "POST"] }
+});
+new IoRemotesService(io.sockets).on('error', console.error);
+io.httpServer.on('listening', () => {
+	console.log(`Relay service listening on ${io.httpServer.address().port}`);
+});


### PR DESCRIPTION
To maintain close homology with the base project, the [`TodoStore`](js/store.js) maintains an in-memory array of todos – meaning the data is stored in 3 locations: in m-ld, in the array, and in the DOM. The array can be bypassed in future by updating the DOM directly from m-ld queries.

Also, the method names are now awkward:

| Method         | New Semantic                                 | Better Name |
|----------------|----------------------------------------------|-------------|
| `_readStorage` | Connect to, read, and follow the m-ld domain | `_connect`  |
| `_save`        | Perform a specific write to the domain       | `_write`    |

- The existing pattern of re-rendering in full has been kept for now; we can switch to the [more selective events branch](https://github.com/1Marc/modern-todomvc-vanillajs/commit/fc89da1a6bd15489d5256575a4e193e11efd8d43) in future.
- No local storage is being used any more – probably better to switch to the Cache API to store the binary m-ld domain data.
