### PR TITLE
Replace inline style with `hidden` attribute.

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -390,7 +390,3 @@ html .clear-completed:active {
 	box-shadow: 0 0 2px 2px #cf7d7d;
 	outline: 0;
 }
-
-[hidden] {
-	display: none !important;
-}

--- a/css/index.css
+++ b/css/index.css
@@ -390,3 +390,7 @@ html .clear-completed:active {
 	box-shadow: 0 0 2px 2px #cf7d7d;
 	outline: 0;
 }
+
+[hidden] {
+	display: none !important;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -10,13 +10,13 @@ const App = {
 		clear: document.querySelector('[data-todo="clear-completed"]'),
 		list: document.querySelector('[data-todo="list"]'),
 		showMain(show) {
-			document.querySelector('[data-todo="main"]').style.display = show ? "block" : "none";
+			document.querySelector('[data-todo="main"]').hidden = !show;
 		},
 		showFooter(show) {
-			document.querySelector('[data-todo="footer"]').style.display = show ? "block" : "none";
+			document.querySelector('[data-todo="footer"]').hidden = !show;
 		},
 		showClear(show) {
-			App.$.clear.style.display = show ? "block" : "none";
+			App.$.clear.hidden = !show;
 		},
 		setActiveFilter(filter) {
 			document.querySelectorAll(`[data-todo="filters"] a`).forEach((el) => {


### PR DESCRIPTION
The hidden attribute serves the purpose of hiding content from the document. We can have multiple display options rather that `block` specially with responsive design where having different display value based on the viewport might be required. Switching to the hidden attribute allow us to control the display with ease and shift the display to the CSS files.

I had to set the display of the hidden element to none with important to ensure having a specificity higher than the target elements if there are other display values applied to them.