### PR TITLE
Update `add()` method to receive only title & Remove whitespaces from input

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -45,12 +45,8 @@ const App = {
 			App.render();
 		});
 		App.$.input.addEventListener("keyup", (e) => {
-			if (e.key === "Enter" && e.target.value.length) {
-				Todos.add({
-					title: e.target.value,
-					completed: false,
-					id: "id_" + Date.now(),
-				});
+			if (e.key === "Enter" && e.target.value.trim()) {
+				Todos.add({ title: e.target.value.trim() });
 				App.$.input.value = "";
 			}
 		});
@@ -78,9 +74,9 @@ const App = {
 		});
 		App.todoEvent("keyup", '[data-todo="edit"]', (todo, $li, e) => {
 			let $input = $li.querySelector('[data-todo="edit"]');
-			if (e.key === "Enter" && $input.value) {
+			if (e.key === "Enter" && $input.value.trim()) {
 				$li.classList.remove("editing");
-				Todos.update({ ...todo, title: $input.value });
+				Todos.update({ ...todo, title: $input.value.trim() });
 			}
 			if (e.key === "Escape") {
 				document.activeElement.blur();

--- a/js/store.js
+++ b/js/store.js
@@ -34,9 +34,9 @@ export const TodoStore = class extends EventTarget {
 		this.dispatchEvent(new CustomEvent("save"));
 	}
 	// MUTATE methods
-	add(todo) {
+	add({ title }) {
 		this.todos.push({
-			title: todo.title,
+			title,
 			completed: false,
 			id: "id_" + Date.now(),
 		});


### PR DESCRIPTION
- `completed` & `id` are handled by `add()` method, so there is no need to pass them when a user clicked Enter.
- Remove whitespaces from input to avoid empty todos. from @ahelmi365 PR.